### PR TITLE
clamonacc: Fix stack buffer overflow with old curl

### DIFF
--- a/clamonacc/client/communication.c
+++ b/clamonacc/client/communication.c
@@ -87,7 +87,9 @@ int onas_sendln(CURL *curl, const void *line, size_t len, int64_t timeout)
     curlcode = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
 #else
     /* Use deprecated CURLINFO_LASTSOCKET option */
-    curlcode = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &sockfd);
+    long long_sockfd;
+    curlcode = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &long_sockfd);
+    sockfd = (curl_socket_t) long_sockfd;
 #endif
 
     if (CURLE_OK != curlcode) {
@@ -152,7 +154,9 @@ int onas_recvln(struct onas_rcvln *rcv_data, char **ret_bol, char **ret_eol, int
     rcv_data->curlcode = curl_easy_getinfo(rcv_data->curl, CURLINFO_ACTIVESOCKET, &sockfd);
 #else
     /* Use deprecated CURLINFO_LASTSOCKET option */
-    rcv_data->curlcode = curl_easy_getinfo(rcv_data->curl, CURLINFO_LASTSOCKET, &sockfd);
+    long long_sockfd;
+    rcv_data->curlcode = curl_easy_getinfo(rcv_data->curl, CURLINFO_LASTSOCKET, &long_sockfd);
+    sockfd = (curl_socket_t) long_sockfd;
 #endif
 
     if (CURLE_OK != rcv_data->curlcode) {


### PR DESCRIPTION
curl_easy_getinfo expects a long for CURLINFO_ACTIVESOCKET, but
curl_socket_t is an int, which was causing a stack buffer overflow
and crash.